### PR TITLE
Logic error in chamber indicator when in single

### DIFF
--- a/beer-panel.php
+++ b/beer-panel.php
@@ -42,7 +42,7 @@
 	<div id="logo-container">
 		<img src="brewpi_logo.png">
 		<div id=beer-name-container>
-			<span>Fermenting: </span><a href='#' id="beer-name"><?php echo urldecode($beerName);?></a><?php echo ($chamber=='' ? 'BrewPi Legacy Remix' : ' in ' . $chamber);?>
+			<span>Fermenting: </span><a href='#' id="beer-name"><?php echo urldecode($beerName);?></a><?php echo ($chamber=='' ? '' : ' in ' . $chamber);?>
 			<span class="data-logging-state"></span>
 		</div>
 	</div>


### PR DESCRIPTION
- Added version checking to daemon unit file setup
- Changed BrewPi start time to <= seconds
- Fixed some typos
- Reduced time delay after flash
- Fixed a logic bug when resetting password
- Removed some errors when deleting non-existent files
- Removed some pi requirements
- Fixed a logic error which displayed a "chamber" indicator in single chamber mode
